### PR TITLE
Delayed actions feeds not processed during fulfilment of free payments

### DIFF
--- a/src/Processor.php
+++ b/src/Processor.php
@@ -451,6 +451,9 @@ class Processor {
 			// First payment and subscription amount are free.
 			( $payment->get_lines()->get_amount()->get_number()->is_zero() && $subscription_lines->get_amount()->get_number()->is_zero() )
 		) {
+			// Allow delayed feeds to be processed during fulfilment for free payments (e.g. user registration for entry with discount).
+			\remove_filter( 'gform_is_delayed_pre_process_feed_' . $this->form_id, array( $this, 'maybe_delay_feed' ), 10 );
+
 			$payment->set_status( PaymentStatus::SUCCESS );
 			$payment->save();
 


### PR DESCRIPTION
If a Gravity Forms entry results in a free payment, for example through discount, the delayed actions of the payment feed are not processed during fulfilment. The `Extension::fulfill_order( $entry )` is called correctly for this entry and `$addon->maybe_process_feed( $entry, $form )` too.

However, because we add the `gform_is_delayed_pre_process_feed_{form_id}` hook in `Processor::add_hooks()`, the feed does not actually get processed.

This PR removes the added filter to delay processing of the feed if the payment status is set early on to 'Success', because there is no amount to be paid. In this case, the successful payment notification will be send, the entry payment status will be updated to 'Paid', so I think the delayed feed should also be processed.