### PR TITLE
Add support for `3 stuks` product field quanity

### DIFF
--- a/src/Processor.php
+++ b/src/Processor.php
@@ -12,6 +12,7 @@ namespace Pronamic\WordPress\Pay\Extensions\GravityForms;
 
 use GFCommon;
 use Pronamic\WordPress\Number\Number;
+use Pronamic\WordPress\Number\Parser as NumberParser;
 use Pronamic\WordPress\Money\Currency;
 use Pronamic\WordPress\Money\Money;
 use Pronamic\WordPress\Pay\AbstractGatewayIntegration;
@@ -356,9 +357,24 @@ class Processor {
 						$line->set_unit_price( new Money( $value, $currency ) );
 
 						if ( array_key_exists( 'quantity', $product ) ) {
-							$quantity = Number::from_mixed( $product['quantity'] );
+							try {
+								$parser = new NumberParser();
 
-							$value = $value->multiply( $quantity );
+								$quantity = $parser->parse( $product['quantity'] );
+
+								$value = $value->multiply( $quantity );
+							} catch ( \Exception $exception ) {
+								$exception = new \Exception(
+									\sprintf(
+										'Couldn’t parse Gravity Forms product field `%s` quantity to a number.',
+										\esc_html( $key )
+									),
+									0,
+									$e
+								);
+
+								throw $exception;
+							}
 						}
 
 						$line->set_total_amount( new Money( $value, $currency ) );

--- a/src/Processor.php
+++ b/src/Processor.php
@@ -370,7 +370,7 @@ class Processor {
 										\esc_html( $key )
 									),
 									0,
-									$e
+									$exception
 								);
 
 								throw $exception;


### PR DESCRIPTION
- https://github.com/pronamic/wp-pronamic-pay-gravityforms/issues/40

<img width="1631" alt="Scherm­afbeelding 2024-05-28 om 11 23 21" src="https://github.com/pronamic/wp-pronamic-pay-gravityforms/assets/869674/81d0a2a9-e015-4120-95cc-cde932e4d4ee">
